### PR TITLE
added report and roadmap schemas, fixed type on AndroidManifest file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:name=".dataAccessLayer.realmConfig"
+        android:name=".dataAccessLayer.RealmConfig"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/fall2022_group20/MainActivity.java
+++ b/app/src/main/java/com/fall2022_group20/MainActivity.java
@@ -4,11 +4,15 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
 
+import io.realm.Realm;
+
 public class MainActivity extends AppCompatActivity {
+    private Realm realm;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        realm = Realm.getDefaultInstance();
     }
 }

--- a/app/src/main/java/com/fall2022_group20/dataAccessLayer/Report/ReportSchema.java
+++ b/app/src/main/java/com/fall2022_group20/dataAccessLayer/Report/ReportSchema.java
@@ -1,0 +1,36 @@
+package com.fall2022_group20.dataAccessLayer.Report;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class ReportSchema extends RealmObject {
+
+    @PrimaryKey
+    private String id;
+    private String childName;
+    private Integer childScore;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getChildName() {
+        return childName;
+    }
+
+    public void setChildName(String childName) {
+        this.childName = childName;
+    }
+
+    public Integer getChildScore() {
+        return childScore;
+    }
+
+    public void setChildScore(Integer childScore) {
+        this.childScore = childScore;
+    }
+}

--- a/app/src/main/java/com/fall2022_group20/dataAccessLayer/RoadMap/RoadMapSchema.java
+++ b/app/src/main/java/com/fall2022_group20/dataAccessLayer/RoadMap/RoadMapSchema.java
@@ -1,0 +1,33 @@
+package com.fall2022_group20.dataAccessLayer.RoadMap;
+
+import io.realm.RealmList;
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class RoadMapSchema extends RealmObject {
+
+    @PrimaryKey
+    private Integer id;
+    private String roadMapName;
+    /* Can't create these fields as we don't have the schemas created yet
+    * private RealmList<LessonSchema> lessons;
+    * private TestSchema test;
+    * */
+
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getRoadMapName() {
+        return roadMapName;
+    }
+
+    public void setRoadMapName(String roadMapName) {
+        this.roadMapName = roadMapName;
+    }
+}


### PR DESCRIPTION
This PR adds the roadmap and report schema. The roadmap schema is missing fields because I need to reference lesson schema and test schema, I will add them once we have all of the schemas completed. Fixed a type in AndroidManifest.xml and added packages for each schema. 

To test: 
1. Pull latest changes to local main branch. 
2. Checkout to julio/reportRoadMapSchema branch
3. Run and build the app, you should only see the Hello World screen (this is not important). 
4. Open Device File Explorer, it should to the right of the emulator. 
![device file explorer](https://user-images.githubusercontent.com/45129978/198038397-2c6f1187-9314-4f3f-bc7e-daceae868a84.png)
5. Look for > data > data > com.fall2022_group20 > files > default.realm
6. Right click on default.realm and save as somewhere easy to find, go to the file location and open it with realm studio. 
7. Inspect Report and RoadMap schemas are there with their respective fields. 

![schemas](https://user-images.githubusercontent.com/45129978/198039673-8d2d8da8-e93d-4c9c-b37f-7043072c3b46.png)
