### PR TITLE
added get report by child name method to child service

### DIFF
--- a/app/src/main/java/com/fall2022_group20/MainActivity.java
+++ b/app/src/main/java/com/fall2022_group20/MainActivity.java
@@ -4,6 +4,9 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.util.Log;
+
+import com.fall2022_group20.dataAccessLayer.child.ChildSchemaService;
 import com.fall2022_group20.realmImporter.JsonSampleData;
 import io.realm.Realm;
 
@@ -22,6 +25,14 @@ public class MainActivity extends AppCompatActivity {
 
         JsonSampleData jsonSampleData = new JsonSampleData(realm, resources);
         jsonSampleData.importDataFromJson();
+
+        ChildSchemaService childService = new ChildSchemaService();
+
+        // This is casting to string so that it can be printed to the console as example
+        // Do not use string values of realm results, it does not work that way
+        Log.i("Child", String.valueOf(childService.getAllChildSchemas()));
+        Log.i("Child Report", String.valueOf(childService.getReportByChildName("Child Zero").getChildScore()));
+
     }
 
     @Override

--- a/app/src/main/java/com/fall2022_group20/MainActivity.java
+++ b/app/src/main/java/com/fall2022_group20/MainActivity.java
@@ -32,7 +32,6 @@ public class MainActivity extends AppCompatActivity {
         // Do not use string values of realm results, it does not work that way
         Log.i("Child", String.valueOf(childService.getAllChildSchemas()));
         Log.i("Child Report", String.valueOf(childService.getReportByChildName("Child Zero").getChildScore()));
-
     }
 
     @Override

--- a/app/src/main/java/com/fall2022_group20/dataAccessLayer/Report/ReportSchemaService.java
+++ b/app/src/main/java/com/fall2022_group20/dataAccessLayer/Report/ReportSchemaService.java
@@ -18,6 +18,11 @@ public class ReportSchemaService {
         return reportId;
     }
 
+    public ReportSchemaService(Realm realm){
+        this.realm = realm;
+
+    }
+
     public ReportSchemaService(Realm realm, String childId, String childName, Integer childScore) {
 
         this.realm = realm;
@@ -73,6 +78,14 @@ public class ReportSchemaService {
     * */
     public ReportSchema getChildReportByName(){
         return realm.where(ReportSchema.class).equalTo("childName", childName).findFirst();
+    }
+
+    /*
+     * Method to return an individual report
+     * We are looking for a report by name, it can be changed to look for id as well
+     * */
+    public ReportSchema getChildReportByName(String name){
+        return realm.where(ReportSchema.class).equalTo("childName", name).findFirst();
     }
 
     /*

--- a/app/src/main/java/com/fall2022_group20/dataAccessLayer/child/ChildSchema.java
+++ b/app/src/main/java/com/fall2022_group20/dataAccessLayer/child/ChildSchema.java
@@ -17,6 +17,8 @@ public class ChildSchema extends RealmObject {
     private ReportSchema report;
     private RoadMapSchema roadmap;
 
+
+
     public String getChildId() {
         return childId;
     }

--- a/app/src/main/java/com/fall2022_group20/dataAccessLayer/child/ChildSchema.java
+++ b/app/src/main/java/com/fall2022_group20/dataAccessLayer/child/ChildSchema.java
@@ -17,8 +17,6 @@ public class ChildSchema extends RealmObject {
     private ReportSchema report;
     private RoadMapSchema roadmap;
 
-
-
     public String getChildId() {
         return childId;
     }

--- a/app/src/main/java/com/fall2022_group20/dataAccessLayer/child/ChildSchemaService.java
+++ b/app/src/main/java/com/fall2022_group20/dataAccessLayer/child/ChildSchemaService.java
@@ -3,6 +3,7 @@ package com.fall2022_group20.dataAccessLayer.child;
 import android.util.Log;
 
 import com.fall2022_group20.dataAccessLayer.Report.ReportSchema;
+import com.fall2022_group20.dataAccessLayer.Report.ReportSchemaService;
 import com.fall2022_group20.dataAccessLayer.RoadMap.RoadMapSchema;
 
 import io.realm.Realm;
@@ -18,8 +19,12 @@ public class ChildSchemaService {
     private Realm realm;
 
     /*
-    Constructor
-     */
+      Constructor
+    */
+    public ChildSchemaService(){
+        this.realm = Realm.getDefaultInstance();
+    }
+
     public ChildSchemaService(Realm realm, String name, ReportSchema report, RoadMapSchema roadmap, String avatar){
         this.realm = realm;
         this.name = name;
@@ -122,5 +127,12 @@ public class ChildSchemaService {
             childSchema.deleteFromRealm();
             childSchema = null;
         });
+    }
+
+    public ReportSchema getReportByChildName(String childName) {
+        ReportSchemaService report = new ReportSchemaService(realm);
+        report.getChildReportByName(childName);
+
+        return report.getChildReportByName(childName);
     }
 }


### PR DESCRIPTION
This PR adds a regular constructor to the child schema service and a method to get the child report by name. 
The example code lines on how to use are in the main activity. 